### PR TITLE
Update test file name in integration test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,9 +61,9 @@ jobs:
         
     - name: Test in git repository
       run: |
-        # Create a test file
-        echo "test" > test.txt
-        git add test.txt
+        # Create a test file with a different name that's not in .gitignore
+        echo "test content" > test_integration.txt
+        git add test_integration.txt
         
         # Set up mock API key
         export GIT_COMMIT_AI_KEY="test-key"


### PR DESCRIPTION
The test file name was changed from 'test.txt' to 'test_integration.txt' to avoid potential conflicts with files listed in .gitignore. This ensures the test file is properly tracked by git during integration tests.

# Please enter the commit message for your changes. Lines starting # with '#' will be ignored, and an empty message aborts the commit. #
# On branch fix-integration-test
#
# Changes to be committed:
# M	.github/workflows/test.yml
#